### PR TITLE
Change name to Si702x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# Driver for the SI702X Temperature/Humidity Sensor
+# Driver for the Si702x Temperature/Humidity Sensor
 
 Author: [Juan Albanell](https://github.com/juanderful11/)
 
-Driver class for a [Si702X temperature/humidity sensor](http://www.silabs.com/Support%20Documents/TechnicalDocs/Si7021.pdf).
+Driver class for a [Si702x temperature/humidity sensor](http://www.silabs.com/Support%20Documents/TechnicalDocs/Si7021-A20.pdf). This class is compatible with the Si7020 and Si7021 - they differ only in measurement accuracy.
 
 ## Hardware
 
-The SI702X should be connected as follows:
+The Si702x should be connected as follows:
 
-![SI7021 Circuit](./circuit.png)
+![Si7020 Circuit](./circuit.png)
 
 ## Class Usage
 
 ### Constructor
 
-To instantiate a new SI702X object you need to pass in a preconfigured I&sup2;C object and an optional I&sup2;C base address. If no base address is supplied, the default address of `0x80` will be used.
+To instantiate a new Si702x object you need to pass in a preconfigured I&sup2;C object and an optional I&sup2;C base address. If no base address is supplied, the default address of `0x80` will be used.
 
 ```squirrel
 hardware.i2c12.configure(CLOCK_SPEED_100_KHZ)
-tempHumid <- SI7021(hardware.i2c12)
+tempHumid <- Si702x(hardware.i2c12)
 ```
 
 ### Class Methods
 
-### SI702X.readTemp()
+### Si702x.readTemp()
 
 The **readTemp()** method returns the temperature in degrees Celsius:
 
@@ -31,7 +31,7 @@ The **readTemp()** method returns the temperature in degrees Celsius:
 server.log(tempHumid.readTemp() + "C")
 ```
 
-### SI702X.readHumidity()
+### Si702x.readHumidity()
 
 The **readHumidity()** function returns the relative humidity (0% - 100%):
 
@@ -41,4 +41,4 @@ server.log(tempHumid.readHumidity() + "%")
 
 # License
 
-The SI702X library is licensed under the [MIT License](./LICENSE).
+The Si702x library is licensed under the [MIT License](./LICENSE).

--- a/Si702x.class.nut
+++ b/Si702x.class.nut
@@ -2,7 +2,7 @@
 // This file is licensed under the MIT License
 // http://opensource.org/licenses/MIT
 
-class SI702X {
+class Si702x {
     static READ_RH      = "\xF5";
     static READ_TEMP    = "\xF3";
     static PREV_TEMP    = "\xE0";


### PR DESCRIPTION
lowercase 'x'

changed the class name itself from SI702X to Si702x (to match the actual filename) and updated the example stuff to match that.

also, changed the link for the datasheet because SI killed the old one.
